### PR TITLE
Fix empty application type

### DIFF
--- a/lib/smlr.ex
+++ b/lib/smlr.ex
@@ -167,6 +167,7 @@ defmodule Smlr do
       |> Map.put(:resp_body, compress(body, conn.request_path, compressor, opts))
     else
       _ ->
+        :telemetry.execute([:smlr, :request, :pass], %{}, %{path: conn.request_path})
         conn
     end
   end

--- a/lib/smlr.ex
+++ b/lib/smlr.ex
@@ -143,6 +143,10 @@ defmodule Smlr do
     true
   end
 
+  defp check_content_type?(false, [], _opts) do
+    false
+  end
+
   defp check_content_type?(false, [application_type], opts) do
     Enum.any?(Config.config(:types, opts), fn type ->
       String.contains?(application_type, type)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Smlr.MixProject do
   def project do
     [
       app: :smlr,
-      version: "1.0.6",
+      version: "1.0.7",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/smlr_test.exs
+++ b/test/smlr_test.exs
@@ -128,4 +128,15 @@ defmodule SmlrTest do
     assert(Plug.Conn.get_resp_header(conn, "content-encoding") == [])
     assert conn.status == 200
   end
+
+  test "test handles empty application" do
+    conn =
+      conn(:get, "/smlr_types/pets_none")
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("accept-encoding", " deflate;q=1.0 , gzip;q=0.2, br;q=0.9")
+      |> SmlrTest.Router.call([])
+
+    assert(Poison.decode!(conn.resp_body) == %{"pet" => "asdf"})
+    assert conn.status == 200
+  end
 end

--- a/test/support/pets_controller.ex
+++ b/test/support/pets_controller.ex
@@ -15,4 +15,9 @@ defmodule SmlrTest.PetsController do
     |> Plug.Conn.put_resp_content_type("application/zip")
     |> Plug.Conn.send_resp(200, "{\"pet\": \"asdf\"}")
   end
+
+  def index_none(conn, _params) do
+    conn
+    |> Plug.Conn.send_resp(200, "{\"pet\": \"asdf\"}")
+  end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -66,5 +66,6 @@ defmodule SmlrTest.Router do
     get("/pets", PetsController, :index)
     get("/pets_nil", PetsController, :index_nil)
     get("/pets_zip", PetsController, :index_zip)
+    get("/pets_none", PetsController, :index_none)
   end
 end


### PR DESCRIPTION
    if not all types is on dont fail on empty application_type
    
    It is possible for a plug to hand us resp data but not have an
    application type set. if we are filtering on types we should just not
    compress this data.
